### PR TITLE
The Compiler Text was Black In Dark Mode

### DIFF
--- a/app/src/main/java/com/algo/phantoms/algo_phantoms/fragments/CodeFragment.kt
+++ b/app/src/main/java/com/algo/phantoms/algo_phantoms/fragments/CodeFragment.kt
@@ -1,5 +1,6 @@
 package com.algo.phantoms.algo_phantoms.fragments
 
+import android.content.res.Configuration
 import android.os.Bundle
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
@@ -22,11 +23,28 @@ class CodeFragment : Fragment() {
         // Inflate the layout for this fragment
         val view = inflater.inflate(R.layout.fragment_code, container, false)
         binding = FragmentCodeBinding.bind(view)
-        binding.editor.setSyntaxHighlightRules(
-            SyntaxHighlightRule("[0-9]*", "#6512c4"),
-            SyntaxHighlightRule("[^A-Za-z0-9]","#F30E0B"),
-            SyntaxHighlightRule("[A-Za-z]",  "#242322")
-        )
+
+
+        val DarkModeFlags = resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK
+        val isDarkModeOn = DarkModeFlags == Configuration.UI_MODE_NIGHT_YES
+
+        if (isDarkModeOn) {
+            binding.editor.setSyntaxHighlightRules(
+                SyntaxHighlightRule("[0-9]*", "#6512c4"),
+                SyntaxHighlightRule("[^A-Za-z0-9]","#F30E0B"),
+                SyntaxHighlightRule("[A-Za-z]",  "#ffffff")
+            )
+        }
+        else{
+            binding.editor.setSyntaxHighlightRules(
+                SyntaxHighlightRule("[0-9]*", "#6512c4"),
+                SyntaxHighlightRule("[^A-Za-z0-9]","#F30E0B"),
+                SyntaxHighlightRule("[A-Za-z]",  "#242322")
+            )
+        }
+
+
+
         return view
     }
 


### PR DESCRIPTION
If we use this app in android dark mode the compiler text was not visible because it is black. I changed the text color if the dark mode is enable the text color will be changed to white else it become black. 

//before
![BeforeIcode](https://github.com/Algo-Phantoms/Algo-Phantoms-Android/assets/126905285/71d00bf0-e392-4331-8190-6f116c153efe)

// After
![AfterICode](https://github.com/Algo-Phantoms/Algo-Phantoms-Android/assets/126905285/d534ed8b-75b7-4f67-8053-ace23900c6c5)
